### PR TITLE
pseudo: override PSEUDO_PASSWD default

### DIFF
--- a/conf/distro/openxt.conf
+++ b/conf/distro/openxt.conf
@@ -12,6 +12,9 @@ PREFERRED_VERSION_lvm2 = "2.02.85"
 PREFERRED_VERSION_networkmanager = "0.9.2.0"
 PREFERRED_VERSION_network-manager-applet = "0.9.2.0"
 PREFERRED_VERSION_pseudo = "1.3"
+# PSEUDO_PASSWD override required until we move up to current pseudo
+# which supports multiple PASSWD targets (as specified by default in oe-core)
+PSEUDO_PASSWD="${STAGING_DIR_TARGET}"
 PREFERRED_VERSION_vim = "7.2.446"
 PREFERRED_VERSION_vim_tiny = "7.2.446"
 PREFERRED_VERSION_wpa-supplicant = "0.7.3"


### PR DESCRIPTION
Newer pseudo supports multiple passwd paths, but we
are still using pseudo 1.3.  Override the default
(specified in oe-core) until we can uprev pseudo.

Signed-off-by: Chris Patterson pattersonc@ainfosec.com
