### PR TITLE
Fix do_install failures on libsepol.

### DIFF
--- a/recipes-security/selinux/libselinux_2.4.bbappend
+++ b/recipes-security/selinux/libselinux_2.4.bbappend
@@ -1,0 +1,5 @@
+#
+# Ensure that we're using our own version of coreutils, rather than
+# the host's coreutils, as we'll need to use ln --relative.
+#
+DEPENDS += "coreutils-native"

--- a/recipes-security/selinux/libsepol_2.4.bbappend
+++ b/recipes-security/selinux/libsepol_2.4.bbappend
@@ -1,0 +1,5 @@
+#
+# Ensure that we're using our own version of coreutils, rather than
+# the host's coreutils, as we'll need to use ln --relative.
+#
+DEPENDS += "coreutils-native"


### PR DESCRIPTION
This really should be fixed in meta-selinux, but this will do until @cjp256 convinces upstream to accept a fix. 
