### PR TITLE
bitbake warning for sysvinit

### DIFF
--- a/recipes-core/sysvinit/sysvinit_2.86.bb
+++ b/recipes-core/sysvinit/sysvinit_2.86.bb
@@ -7,7 +7,7 @@ PR = "r61"
 
 # USE_VT and SERIAL_CONSOLE are generally defined by the MACHINE .conf.
 # Set PACKAGE_ARCH appropriately.
-PACKAGE_ARCH_${PN}-inittab = "${MACHINE_ARCH}"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 DEPENDS += "libselinux"
 RDEPENDS_${PN} = "${PN}-inittab"


### PR DESCRIPTION
The package is already machine specific and bitbakes warns about it:
WARNING: Recipe sysvinit is marked as only being architecture specific
but seems to have machine specific packages?! The recipe may as well
mark itself as machine specific directly.
