### PR TITLE
Avoid using cross-localedef for glibc-locale

### DIFF
--- a/recipes-core/glibc/glibc-locale_2.22.bbappend
+++ b/recipes-core/glibc/glibc-locale_2.22.bbappend
@@ -1,0 +1,7 @@
+# WORKAROUND: Avoid glibc abort() from presumed invalid locale binaries:
+# cross-localdef seems to generate a LC_LOCATE that fails to be parsed by the
+# glibc deployed on the target.
+
+# set "1" to use cross-localedef for locale generation
+# set "0" for qemu emulation of native localedef for locale generation
+LOCALE_GENERATION_WITH_CROSS-LOCALEDEF = "0"


### PR DESCRIPTION
Work-around to avoid glibc abort() when trying to parse LC_COLLATE file
pre-generated by cross-localedef.

Using LANG="en_US" (and probably others) would abort() with the
following assertion:
tty: loadlocale.c:130: _nl_intern_locale_data: Assertion `cnt < (sizeof (_nl_value_type_LC_COLLATE) / sizeof (_nl_value_type_LC_COLLATE[0]))' failed.
