### PR TITLE
[bootage] xcpmd depends on acpid

### DIFF
--- a/recipes-openxt/bootage/bootage/bootage.conf-xenclient_dom0
+++ b/recipes-openxt/bootage/bootage/bootage.conf-xenclient_dom0
@@ -72,7 +72,7 @@ script xenclient-vusb-daemon
 dep dbus-1 udev xenstored surfman xenmgr
 
 script xcpmd
-dep dbus-1 xenstored surfman
+dep dbus-1 xenstored surfman acpid
 
 script surfman
 dep dbus-1 xenstored


### PR DESCRIPTION
Missing dep was causing xcpmd to not start on system boot.
